### PR TITLE
docs: add simplified architecture guide for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,16 @@ GreenCode/
 └── docker-compose.yml   # Docker orchestration
 
 
+
+
+## Simplified Architecture Guide (For Beginners)
+
+GreenCode is built using three main layers:
+
+1. **Frontend** — The React user interface that people interact with in the browser.
+2. **Backend API** — A Spring Boot application that handles all business logic and data processing.
+3. **Database** — PostgreSQL stores all data permanently, while H2 is used for testing.
+
+These three layers communicate with each other over HTTP using REST APIs.
+When a user clicks a button on the frontend, a request is sent to the backend,
+which then reads or writes data to the database and sends a response back.


### PR DESCRIPTION
## Summary
This PR adds a simplified architecture explanation to help new 
contributors understand the GreenCode system structure quickly.

## Changes Made
- Added a Simplified Architecture Guide section to README.md
- Explains the three main layers in plain language
- Describes how Frontend, Backend API and Database communicate

## Related Issue
Closes #33

## Why This Is Useful
New contributors struggled to understand the existing architecture 
documentation. This change makes onboarding faster and more accessible.