### PR TITLE
docs: add React frontend setup and launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ GreenCode/
 └── docker-compose.yml   # Docker orchestration
 
 
+### 🛠️ Frontend Setup & Launch
+To get the React frontend running locally:
+1. Navigate to the frontend directory: `cd greencode-frontend`
+2. Install dependencies: `npm install`
+3. Start the development server: `npm start`
+4. Access the UI at `http://localhost:3000`


### PR DESCRIPTION
This PR addresses Issue #1. It adds clear installation and startup steps for the React frontend to help new developers