### PR TITLE
docs: Add Getting Started / Setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,51 @@
-# GreenCode
+## Getting Started
 
-GreenCode is a full-stack system designed to support environmental, sustainability, and community-impact projects under Bos-Com.  
-It consists of a **Spring Boot backend API** and a **React frontend** (new addition), with future integrations planned.
+### Prerequisites
+Make sure you have the following installed before running the project:
 
----
+- Java 17+
+- Node.js 18+
+- Docker & Docker Compose
+- PostgreSQL 14+
 
-## 🚀 Features
+### Backend Setup
+1. Clone the repository
+```bash
+   git clone https://github.com/your-org/greencode.git
+   cd greencode
+```
+2. Copy the environment file and fill in your values
+```bash
+   cp .env.example .env
+```
+3. Run the backend with Docker
+```bash
+   docker-compose up --build
+```
+4. The API will be available at `http://localhost:8080`
+5. Swagger docs at `http://localhost:8080/swagger-ui.html`
 
-### Backend (Spring Boot)
-- RESTful API
-- JWT/OAuth authentication
-- PostgreSQL database support
-- Centralised configuration (`config/`, `.env`)
-- Dockerized for easy deployment
-- Swagger/OpenAPI documentation
+### Frontend Setup
+1. Navigate to the frontend folder
+```bash
+   cd greencode-frontend
+```
+2. Install dependencies
+```bash
+   npm install
+```
+3. Start the development server
+```bash
+   npm start
+```
+4. The app will be available at `http://localhost:3000`
 
-### Frontend (React)
-- Modern React (Create React App)
-- React Router for navigation
-- Axios for API communication
-- Authentication UI (login, password reset flow)
-- Responsive UI with Tailwind CSS (recommended)
-- Ready to connect to backend reset API
+### Environment Variables
+Create a `.env` file in the root directory based on `.env.example`. Key variables include:
 
----
-
-## 📁 Project Structure
-GreenCode/
-├── src/                 # Spring Boot source code
-├── config/              # external configuration & scripts
-├── docs/                # architecture, API docs
-├── greencode-frontend/  # React frontend (new)
-├── pom.xml              # Maven build file
-└── docker-compose.yml   # Docker orchestration
-
-
+| Variable | Description |
+|---|---|
+| `DB_URL` | PostgreSQL connection URL |
+| `DB_USERNAME` | Database username |
+| `DB_PASSWORD` | Database password |
+| `JWT_SECRET` | Secret key for JWT tokens |


### PR DESCRIPTION
Closes #<56>

     Added a Getting Started section covering:
     - Prerequisites
     - Backend and frontend setup steps
     - Environment variable guidance
