### PR TITLE
docs: fix actuator health endpoint references

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -44,4 +44,6 @@ curl -X GET http://localhost:8080/api/users \
 
 - **Swagger UI**: Available at `/swagger-ui.html`
 - **OpenAPI Spec**: Available at `/api-docs`
-- **Health Check**: Available at `/health`
+- **Health Check**: Available at `/api/actuator/health`
+- **Actuator Metrics**: Available at `/api/actuator/metrics`
+- **Actuator Info**: Available at `/api/actuator/info`

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -62,9 +62,9 @@ java -jar target/greencode-backend-1.0.0.jar
 
 ## 📊 Monitoring
 
-- **Health**: `/actuator/health`
-- **Metrics**: `/actuator/metrics`
-- **Info**: `/actuator/info`
+- **Health**: `/api/actuator/health`
+- **Metrics**: `/api/actuator/metrics`
+- **Info**: `/api/actuator/info`
 - **Logs**: Check container logs
 
 ## 🆘 Troubleshooting


### PR DESCRIPTION
## Summary
- update API docs health check path to /api/actuator/health
- document related actuator endpoints (/api/actuator/metrics, /api/actuator/info)
- align deployment monitoring docs with the same endpoint paths

## Why
Documentation previously pointed to /health, which conflicts with the actual actuator endpoint structure and can break deployment checks.

Closes #28
