### PR TITLE
Add CONTRIBUTING.md, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible problem in GreenCode
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+Describe the problem and the user impact.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What should happen?
+
+## Actual Behavior
+
+What happens instead?
+
+## Environment
+
+- Java version:
+- Maven version:
+- Operating system:
+- Run mode: local / Docker
+
+## Verification Notes
+
+List any commands, logs, or screenshots that help confirm the issue.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,25 @@
+---
+name: Documentation improvement
+about: Improve setup, API, architecture, or contributor documentation
+title: "docs: "
+labels: documentation
+assignees: ""
+---
+
+## Documentation Area
+
+Which page, section, or workflow needs improvement?
+
+## Problem
+
+What is unclear, outdated, missing, or hard to follow?
+
+## Proposed Change
+
+Describe the documentation update that would resolve the issue.
+
+## Acceptance Criteria
+
+- [ ] The updated documentation is accurate for the current repository.
+- [ ] Links and commands are verified where possible.
+- [ ] Related docs are cross-linked if useful.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature enhancement
+- [ ] Documentation update
+- [ ] UI/UX improvement
+- [ ] Governance or sustainability improvement
+
+## Verification
+
+- [ ] `mvn test`
+- [ ] Documentation-only change; no runtime tests needed
+
+## Notes for Reviewers
+
+Add any migration, deployment, or follow-up notes here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to GreenCode
+
+Thanks for helping improve GreenCode. This guide keeps contributions focused,
+reviewable, and easy for maintainers to merge.
+
+## Before You Start
+
+1. Check GitHub Issues for an existing report or proposal.
+2. Open a new issue if the work is not already tracked.
+3. Keep each pull request focused on one bug fix, feature, documentation update,
+   or governance improvement.
+
+## Development Workflow
+
+1. Fork the repository and clone your fork.
+2. Create a branch from `main`:
+
+   ```bash
+   git checkout -b docs/update-setup-guide
+   ```
+
+3. Install prerequisites listed in the README.
+4. Make the smallest complete change that resolves the issue.
+5. Run the relevant checks:
+
+   ```bash
+   mvn test
+   ```
+
+6. Commit with a conventional commit prefix such as `fix:`, `feat:`, `docs:`,
+   or `style:`.
+7. Open a pull request and include the issue reference, testing notes, and any
+   deployment or configuration impact.
+
+## Pull Request Checklist
+
+- The PR links the issue it resolves.
+- The change is scoped to one reviewable topic.
+- Documentation is updated when behavior or setup steps change.
+- Relevant tests pass locally, or skipped checks are explained.
+- No secrets, local credentials, build artifacts, or generated logs are included.
+
+## Code Expectations
+
+- Follow the existing Spring Boot package structure.
+- Prefer service-layer business rules over controller-only logic.
+- Keep API responses free of sensitive fields such as passwords.
+- Add or update tests when changing controllers, services, repositories, or
+  validation behavior.


### PR DESCRIPTION
 What changed
- Added CONTRIBUTING.md with full contribution workflow
- Added GitHub issue templates for bug reports and feature requests
- Added PR template with checklist

Why
The repository had no contributor workflow documentation, making it 
hard for new contributors to know how to submit issues or pull requests 
correctly.

Closes #92