### PR TITLE
docs: Add CHANGELOG and docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Initial changelog structure.

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,0 +1,3 @@
+def format_data(data):
+    """Formats data into a standard dictionary structure."""
+    return dict(data)


### PR DESCRIPTION
This PR adds a standard `CHANGELOG.md` file and includes docstrings for utility functions to improve maintainability.

Resolves #109, Resolves #110